### PR TITLE
Fix casing of packages vs Packages for case-sensitive filesystems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,13 +148,13 @@ publish/
 
 # NuGet Packages
 *.nupkg
-# The packages folder can be ignored because of Package Restore
-#**/packages/*
-**/packages/**/*.xml
+# The Packages folder can be ignored because of Package Restore
+#**/Packages/*
+**/Packages/**/*.xml
 # except build/, which is used as an MSBuild target.
-!**/packages/build/
+!**/Packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
-#!**/packages/repositories.config
+#!**/Packages/repositories.config
 # NuGet v3's project.json files produces more ignoreable files
 *.nuget.props
 *.nuget.targets

--- a/Extensions/Es20Backend/Es20Backend.csproj
+++ b/Extensions/Es20Backend/Es20Backend.csproj
@@ -40,7 +40,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
+      <HintPath>..\..\Packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Extensions/GL21Backend/GL21Backend.csproj
+++ b/Extensions/GL21Backend/GL21Backend.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
+      <HintPath>..\..\Packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Extensions/OpenTKBackend/OpenTKBackend.csproj
+++ b/Extensions/OpenTKBackend/OpenTKBackend.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="OpenTK, Version=1.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
+      <HintPath>..\..\Packages\AdamsLair.OpenTK.1.2.2\lib\net20\OpenTK.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This was failing to build on Linux, at least with xbuild.