### PR TITLE
Add /output <DIR> switch to Import tool

### DIFF
--- a/Tools/Import/Downloaders/DemoDownloader.cs
+++ b/Tools/Import/Downloaders/DemoDownloader.cs
@@ -11,7 +11,7 @@ namespace Import.Downloaders
     {
         private const string Url = "http://deat.tk/public/jazz2/demo.zip";
 
-        public static bool Run(string targetPath)
+        public static bool Run(string targetPath, string exePath)
         {
             Log.Write(LogType.Info, "Downloading Shareware Demo (7 MB)...");
             Log.PushIndent();
@@ -45,7 +45,7 @@ namespace Import.Downloaders
                 usedMusic.Add("bonus3");
                 usedMusic.Add("menu");
 
-                App.ConvertJJ2Anims(tempDir, targetPath);
+                App.ConvertJJ2Anims(tempDir, targetPath, exePath);
                 App.ConvertJJ2Levels(tempDir, targetPath, usedTilesets, usedMusic);
                 App.ConvertJJ2Cinematics(tempDir, targetPath, usedMusic, false);
                 App.ConvertJJ2Music(tempDir, targetPath, usedMusic, false);


### PR DESCRIPTION
This writes the content to the specified directory instead of where the executables are. The argument handling had to be adjusted so that this could also be used for the automatic demo download.

The reason behind this is that I'm creating one package for Jazz² and one for the commercial/demo data. Many package managers install to a staging directory first and actively prevent you from writing directly outside the build area. I therefore need to source the Jazz² content from the system but write the import output to the staging directory.

This was admittedly a bit more involved than I had initially expected since you read, write, and delete these files. I basically applied `exePath` to content provided by Jazz² (e.g. Shaders) rather than the game itself (e.g. Tilesets).

I do see confusing errors during the import about things like missing tilesets and this one when starting a level but these appear without this change too.

```
 ˙ Can't load animation "FallShootToFall" from metadata "Interactive/PlayerJazz": File "Animations\Jazz\unused_jump_shoot_end.png.res" was not found in CompressedContent
 ˙ Can't load animation "LedgeClimb" from metadata "Interactive/PlayerJazz": File "Animations\Jazz\unused_ledge_climb.png.res" was not found in CompressedContent
```