### PR TITLE
Have Import tool use exising files instead of downloading, if possible

### DIFF
--- a/Tools/Import/Downloaders/DemoDownloader.cs
+++ b/Tools/Import/Downloaders/DemoDownloader.cs
@@ -13,19 +13,24 @@ namespace Import.Downloaders
 
         public static bool Run(string targetPath, string exePath)
         {
-            Log.Write(LogType.Info, "Downloading Shareware Demo (7 MB)...");
-            Log.PushIndent();
+            string zipFile = Path.GetFileName(Url);
+            bool zipExists = File.Exists(zipFile);
 
-            string zipFile = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
+            if (!zipExists) {
+                Log.Write(LogType.Info, "Downloading Shareware Demo (7 MB)...");
+                Log.PushIndent();
 
-            try {
-                using (WebClient client = new WebClient()) {
-                    client.DownloadFile(Url, zipFile);
+                zipFile = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
+
+                try {
+                    using (WebClient client = new WebClient()) {
+                        client.DownloadFile(Url, zipFile);
+                    }
+                } catch (Exception ex) {
+                    Log.Write(LogType.Error, "Failed to download required files: " + ex.ToString());
+                    Log.PopIndent();
+                    return false;
                 }
-            } catch (Exception ex) {
-                Log.Write(LogType.Error, "Failed to download required files: " + ex.ToString());
-                Log.PopIndent();
-                return false;
             }
 
             string tempDir = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
@@ -55,8 +60,10 @@ namespace Import.Downloaders
                 Log.PopIndent();
                 return false;
             } finally {
-                // Try to delete downloaded ZIP file
-                FileSystemUtils.FileTryDelete(zipFile);
+                if (!zipExists) {
+                    // Try to delete downloaded ZIP file
+                    FileSystemUtils.FileTryDelete(zipFile);
+                }
 
                 // Try to delete extracted files
                 FileSystemUtils.DirectoryTryDelete(tempDir, true);

--- a/Tools/Import/Downloaders/JJ2PlusDownloader.cs
+++ b/Tools/Import/Downloaders/JJ2PlusDownloader.cs
@@ -14,20 +14,24 @@ namespace Import.Downloaders
         public static bool Run(string targetPath)
         {
             targetPath = Path.Combine(targetPath, "Content", "Animations");
+            string zipFile = Path.GetFileName(Url);
+            bool zipExists = File.Exists(zipFile);
 
-            Log.Write(LogType.Info, "Downloading JJ2+ (3 MB)...");
-            Log.PushIndent();
+            if (!zipExists) {
+                Log.Write(LogType.Info, "Downloading JJ2+ (3 MB)...");
+                Log.PushIndent();
 
-            string zipFile = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
+                zipFile = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
 
-            try {
-                using (WebClient client = new WebClient()) {
-                    client.DownloadFile(Url, zipFile);
+                try {
+                    using (WebClient client = new WebClient()) {
+                        client.DownloadFile(Url, zipFile);
+                    }
+                } catch (Exception ex) {
+                    Log.Write(LogType.Error, "Failed to download required files: " + ex.ToString());
+                    Log.PopIndent();
+                    return false;
                 }
-            } catch (Exception ex) {
-                Log.Write(LogType.Error, "Failed to download required files: " + ex.ToString());
-                Log.PopIndent();
-                return false;
             }
 
             string tempDir = Path.Combine(Path.GetTempPath(), "Jazz2-" + Guid.NewGuid());
@@ -48,8 +52,10 @@ namespace Import.Downloaders
                 Log.PopIndent();
                 return false;
             } finally {
-                // Try to delete downloaded ZIP file
-                FileSystemUtils.FileTryDelete(zipFile);
+                if (!zipExists) {
+                    // Try to delete downloaded ZIP file
+                    FileSystemUtils.FileTryDelete(zipFile);
+                }
 
                 // Try to delete extracted files
                 FileSystemUtils.DirectoryTryDelete(tempDir, true);


### PR DESCRIPTION
It looks for them in the current directory.

Note that it's best to view this without whitespace changes.

The reasoning behind this is that distribution package builders generally don't allow you to download anything during the build itself and sometimes actively prevent it. All required files should be available up front to allow offline builds and manifest checking.

I would ideally like a further change before this is merged. Manifest checking means that published files are not expected to ever change but neither of your downloads are versioned. I am confident enough that demo.zip will never change. If it happens once or twice, it's not the end of the world. jj2plus.zip may change from time to time though. I looked upstream to see whether they have versioned zips there. They actually do but not for the latest version! In any case, it may be a good idea to fix the JJ2 version against the Jazz² version? You don't know for sure that future JJ2 releases will continue to work against old Jazz² releases, right? I also noticed that you only use the Plus.j2a file from the zip and, even uncompressed, this is a lot smaller than the whole zip. Why not just host that file on its own with a versioned filename, e.g. Plus-5.6.j2a?