### PR TITLE
Fix /connect:host:port arg parsing

### DIFF
--- a/Jazz2/App.cs
+++ b/Jazz2/App.cs
@@ -106,7 +106,7 @@ namespace Jazz2.Game
 #if MULTIPLAYER
                 for (int i = 0; i < args.Length; i++) {
                     if (args[i].StartsWith("/connect:", StringComparison.InvariantCulture)) {
-                        int idx = args[i].LastIndexOf(':', 10);
+                        int idx = args[i].IndexOf(':', 10);
                         if (idx == -1) {
                             continue;
                         }


### PR DESCRIPTION
I tried to connect to my own private server but it was just ignoring the `/connect` arg. I eventually figured out why!

While on the subject, I've noticed that if you try to connect to a non-existent server, you just end up with a horribly glitchy window.